### PR TITLE
Move scripts to package.json and Delete bash scripts. Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ virtualenvwrapper is recommended to manage dependencies
 
 ## Client-Side Pre-Requirements
 
-You must have the following installed globally on your machine to successfully install this project:
-
 - Node.js
 - Yarn
 
@@ -45,12 +43,12 @@ There are some shell scripts to easily start things up:
 ## Running Locally
 
 ```
-./dev_run.sh
+yarn run start
 ```
 View the app on `http://localhost:8080/`
 
 ## Deploying to Production
 
 ```
-./deploy.sh
+yarn run deploy
 ```

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-yarn run build
-zappa update prod

--- a/package.json
+++ b/package.json
@@ -5,8 +5,11 @@
   "author": "Bill Gryta",
   "license": "MIT",
   "scripts": {
-    "start": "webpack-dev-server --config webpack.dev.js",
-    "build": "webpack --config webpack.prod.js"
+    "start": "yarn run webpack-server & yarn run flask-server",
+    "build": "webpack --config webpack.prod.js",
+    "webpack-server": "webpack-dev-server --config webpack.dev.js",
+    "flask-server": "FLASK_ENV=development FLASK_APP=app.py flask run",
+    "deploy": "yarn run build && zappa update prod"
   },
   "dependencies": {
     "babel-cli": "^6.26.0",

--- a/run_dev.sh
+++ b/run_dev.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-export FLASK_ENV=development
-yarn run start & FLASK_APP=app.py flask run

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,7 +13,11 @@
 
 <body>
 	<div id="app"></div>
+	{% if environment == 'production' %}
 	<script src="{{ url_for('static', filename='bundle.min.js') }}"></script>
+	{% else %}
+	<script src="{{ url_for('static', filename='bundle.js') }}"></script>
+	{% endif %}
 </body>
 
 </html>

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,12 +1,14 @@
 const path = require("path");
 
 module.exports = {
-  entry: "./src/app.js",
+  entry: {
+      "styles": "./src/styles/styles.scss",
+      "bundle": "./src/app.js"
+  },
   output: {
-    path: path.join(__dirname, "static"),
-    publicPath: "/static/",
-    filename: "bundle.min.js",
-    crossOriginLoading: "anonymous"
+    path: path.resolve(__dirname, "/static"),
+    publicPath: '/static/',
+    filename: "[name].js"
   },
   mode: "development",
   module: {


### PR DESCRIPTION
Move scripts to package.json
To run locally it is now:
`yarn run start`

To deploy to production it is now:
`yarn run deploy`.

Updated readme to reflect these changes.

Note:
the app will now run perfectly on localhost:8080 locally. localhost:5000 does not work locally because webpack-dev-server creates and serves `bundle.js` to `/static/` in memory locally, which is weird. So flask can't serve that file straight from the 5000 port, but the proxy pass will have access to the in memory `/static/bundle.js`
 
